### PR TITLE
[♻️Refactor] 게시글 목록 조회시 N+1 문제 수정

### DIFF
--- a/api/src/main/java/mutsa/api/controller/article/ArticleController.java
+++ b/api/src/main/java/mutsa/api/controller/article/ArticleController.java
@@ -31,7 +31,7 @@ public class ArticleController {
 
     //  조회
     @GetMapping
-    public ResponseEntity<Page<ArticleResponseDto>> getArticleList(
+    public ResponseEntity<Page<ArticlePageResponseDto>> getArticleList(
             @RequestParam(value = "page", defaultValue = "0") Integer page,
             @RequestParam(value = "size", defaultValue = "10") Integer size,
             @RequestParam(value = "order", defaultValue = "DESC") ArticleOrderDirection direction,

--- a/api/src/main/java/mutsa/api/dto/article/ArticlePageResponseDto.java
+++ b/api/src/main/java/mutsa/api/dto/article/ArticlePageResponseDto.java
@@ -1,0 +1,53 @@
+/**
+ * @project backend
+ * @author ARA
+ * @since 2023-08-16 PM 1:20
+ */
+
+package mutsa.api.dto.article;
+
+import static mutsa.common.constants.ImageConstants.DEFAULT_ARTICLE_IMG;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import mutsa.api.dto.image.ImageResponseDto;
+import mutsa.common.domain.models.Status;
+import mutsa.common.domain.models.article.Article;
+import mutsa.common.domain.models.article.ArticleStatus;
+import mutsa.common.domain.models.image.Image;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticlePageResponseDto {
+    private String title;
+    private String description;
+    private String username;
+    private String thumbnail;
+    private String apiId;
+    private Status status;
+    private ArticleStatus articleStatus;
+    private String createdDate;
+    private Long price;
+
+    public static ArticlePageResponseDto to(Article entity) {
+        return ArticlePageResponseDto.builder()
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .username(entity.getUser().getUsername())
+                .thumbnail(entity.getThumbnail())
+                .apiId(entity.getApiId())
+                .status(entity.getStatus())
+                .articleStatus(entity.getArticleStatus())
+                .createdDate(entity.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm:ss")))
+                .price(entity.getPrice())
+                .build();
+    }
+}

--- a/api/src/main/java/mutsa/api/dto/article/ArticleResponseDto.java
+++ b/api/src/main/java/mutsa/api/dto/article/ArticleResponseDto.java
@@ -24,11 +24,10 @@ import static mutsa.common.constants.ImageConstants.DEFAULT_ARTICLE_IMG;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ArticleResponseDto {
-    public static final ImageResponseDto DEFAULT_ARTICLE_IMG_RESPONSE = ImageResponseDto.to(DEFAULT_ARTICLE_IMG);
+//    public static final ImageResponseDto DEFAULT_ARTICLE_IMG_RESPONSE = ImageResponseDto.to(DEFAULT_ARTICLE_IMG);
     private String title;
     private String description;
     private String username;
-    private String thumbnail;
     private String apiId;
     private Status status;
     private ArticleStatus articleStatus;
@@ -36,31 +35,28 @@ public class ArticleResponseDto {
     private List<ImageResponseDto> images;
     private Long price;
 
-    public static ArticleResponseDto to(Article entity) {
+    public static ArticleResponseDto to(Article entity, List<ImageResponseDto> images) {
         return ArticleResponseDto.builder()
                 .title(entity.getTitle())
                 .description(entity.getDescription())
                 .username(entity.getUser().getUsername())
-                .thumbnail(entity.getThumbnail())
                 .apiId(entity.getApiId())
                 .status(entity.getStatus())
                 .articleStatus(entity.getArticleStatus())
                 .createdDate(entity.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm:ss")))
                 .price(entity.getPrice())
-                .images(getImages(entity.getImages()))
+                .images(images)
                 .build();
     }
 
-    private static List<ImageResponseDto> getImages(List<Image> images) {
-        if (images.size() == 0) {
-            return List.of(DEFAULT_ARTICLE_IMG_RESPONSE);
-        }
-        return images.stream().map(ImageResponseDto::to).toList();
-    }
+//    private static List<ImageResponseDto> getImages(List<Image> images) {
+////        if (images.size() == 0) {
+////            return List.of(DEFAULT_ARTICLE_IMG_RESPONSE);
+////        }
+//        return images.stream().map(ImageResponseDto::to).toList();
+//    }
 
     public void addArticleImages(List<ImageResponseDto> images) {
         this.images.addAll(images);
     }
-
-
 }

--- a/api/src/main/java/mutsa/api/service/article/ArticleModuleService.java
+++ b/api/src/main/java/mutsa/api/service/article/ArticleModuleService.java
@@ -62,12 +62,12 @@ public class ArticleModuleService {
         return article;
     }
 
-    @Transactional
-    public Article setImages(Article article, Collection<Image> imageCollection) {
-        article.addImages(imageCollection);
-
-        return articleRepository.save(article);
-    }
+//    @Transactional
+//    public Article setImages(Article article, Collection<Image> imageCollection) {
+//        article.addImages(imageCollection);
+//
+//        return articleRepository.save(article);
+//    }
 
     @Transactional
     public Article saveTest(ArticleCreateRequestDto requestDto) {
@@ -145,9 +145,9 @@ public class ArticleModuleService {
         return articleRepository.getPage(articleFilter, pageable);
     }
 
-    @Transactional
-    public Article deleteImages(Article article) {
-        article.setImages(new ArrayList<>());
-        return articleRepository.save(article);
-    }
+//    @Transactional
+//    public Article deleteImages(Article article) {
+//        article.setImages(new ArrayList<>());
+//        return articleRepository.save(article);
+//    }
 }

--- a/api/src/main/java/mutsa/api/service/article/ArticleService.java
+++ b/api/src/main/java/mutsa/api/service/article/ArticleService.java
@@ -6,16 +6,21 @@
 
 package mutsa.api.service.article;
 
+import java.util.Comparator;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mutsa.api.dto.article.ArticleCreateRequestDto;
 import mutsa.api.dto.article.ArticleFilterDto;
+import mutsa.api.dto.article.ArticlePageResponseDto;
 import mutsa.api.dto.article.ArticleResponseDto;
 import mutsa.api.dto.article.ArticleUpdateRequestDto;
+import mutsa.api.dto.image.ImageResponseDto;
 import mutsa.api.service.image.ImageModuleService;
 import mutsa.api.util.SecurityUtil;
 import mutsa.common.domain.filter.article.ArticleFilter;
 import mutsa.common.domain.models.article.Article;
 import mutsa.common.domain.models.image.Image;
+import mutsa.common.domain.models.image.ImageReference;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -32,29 +37,40 @@ public class ArticleService {
         Article article = articleModuleService.save(requestDto);
 
         if (requestDto.getImages() == null || requestDto.getImages().isEmpty()) {
-            return ArticleResponseDto.to(article);
+            return ArticleResponseDto.to(article, null);
         }
 
-        List<Image> images = imageModuleService.saveAll(requestDto.getImages(), article.getApiId());
-        return ArticleResponseDto.to(articleModuleService.setImages(article, images));
+        List<ImageResponseDto> imageResponseDtos = imageModuleService.saveAll(requestDto.getImages(),
+                        article.getApiId(), ImageReference.ARTICLE)
+                .stream()
+                .sorted(Comparator.comparing(Image::getId))
+                .map(image -> ImageResponseDto.to(image))
+                .collect(Collectors.toList());
+        return ArticleResponseDto.to(article, imageResponseDtos);
     }
 
     public ArticleResponseDto update(ArticleUpdateRequestDto updateDto) {
         Article article = articleModuleService.update(updateDto);
 
         if (updateDto.getImages() == null || updateDto.getImages().isEmpty()) {
-            return ArticleResponseDto.to(article);
+            return ArticleResponseDto.to(article, null);
         }
 
         //  기존에 있던 이미지는 논리 삭제 처리
         imageModuleService.deleteByRefApiId(article.getApiId());
-        article = deleteImages(article);
-        List<Image> images = imageModuleService.saveAll(updateDto.getImages(), article.getApiId());
-        return ArticleResponseDto.to(articleModuleService.setImages(article, images));
+//        article = deleteImages(article);
+        article.setThumbnail(null);
+        List<ImageResponseDto> imageResponseDtos = imageModuleService.saveAll(updateDto.getImages(),
+                article.getApiId(), ImageReference.ARTICLE)
+                .stream()
+                .sorted(Comparator.comparing(Image::getId))
+                .map(image -> ImageResponseDto.to(image))
+                .collect(Collectors.toList());
+        return ArticleResponseDto.to(article, imageResponseDtos);
     }
 
-    protected Article deleteImages(Article article) {
-        return articleModuleService.deleteImages(article);
+    protected void deleteImages(Article article) {
+        imageModuleService.deleteAllByRefId(article.getApiId());
     }
 
     protected Article getByApiId(String apiId) {
@@ -66,16 +82,24 @@ public class ArticleService {
     }
 
     public ArticleResponseDto read(String apiId) {
-        return ArticleResponseDto.to(articleModuleService.getByApiId(apiId));
+        Article articleEntity = articleModuleService.getByApiId(apiId);
+        List<ImageResponseDto> imageResponseDtos = imageModuleService.getAllByRefId(apiId)
+                .stream()
+                //  Id를 기준으로 정렬 수행
+                .sorted(Comparator.comparing(Image::getId))
+                .map(image -> ImageResponseDto.to(image))
+                .collect(Collectors.toList());
+
+        return ArticleResponseDto.to(articleEntity, imageResponseDtos);
     }
 
-    public Page<ArticleResponseDto> getPageByUsername(
+    public Page<ArticlePageResponseDto> getPageByUsername(
             String username, Sort.Direction direction, ArticleFilterDto articleFilter
     ) {
         return getPageByUsername(username, 0, 10, direction, articleFilter);
     }
 
-    public Page<ArticleResponseDto> getPageByUsername(
+    public Page<ArticlePageResponseDto> getPageByUsername(
             String username, int pageNum, int size, Sort.Direction direction, ArticleFilterDto articleFilter
     ) {
         return articleModuleService.getPageByUsername(
@@ -85,10 +109,10 @@ public class ArticleService {
                 direction,
                 "id",
                 ArticleFilterDto.to(articleFilter)
-        ).map(ArticleResponseDto::to);
+        ).map(ArticlePageResponseDto::to);
     }
 
-    public Page<ArticleResponseDto> getPageByUsername(
+    public Page<ArticlePageResponseDto> getPageByUsername(
             String username,
             int pageNum,
             int size,
@@ -103,10 +127,10 @@ public class ArticleService {
                 direction,
                 orderProperties,
                 ArticleFilterDto.to(articleFilter)
-        ).map(ArticleResponseDto::to);
+        ).map(ArticlePageResponseDto::to);
     }
 
-    public Page<ArticleResponseDto> getPage(
+    public Page<ArticlePageResponseDto> getPage(
             int pageNum, int size, Sort.Direction direction, ArticleFilterDto articleFilter
     ) {
         return articleModuleService.getPage(
@@ -115,10 +139,10 @@ public class ArticleService {
                 direction,
                 "id",
                 ArticleFilterDto.to(articleFilter)
-        ).map(ArticleResponseDto::to);
+        ).map(ArticlePageResponseDto::to);
     }
 
-    public Page<ArticleResponseDto> getPage(
+    public Page<ArticlePageResponseDto> getPage(
             int pageNum, int size, Sort.Direction direction, String orderProperties, ArticleFilterDto articleFilter
     ) {
         return articleModuleService.getPage(
@@ -127,7 +151,7 @@ public class ArticleService {
                 direction,
                 orderProperties,
                 ArticleFilterDto.to(articleFilter)
-        ).map(ArticleResponseDto::to);
+        ).map(ArticlePageResponseDto::to);
     }
 
     public void deleteByApiId(String apiId) {
@@ -136,8 +160,7 @@ public class ArticleService {
     }
 
     /**
-     * 유저 호출에 의한 삭제를 할 경우 이 메소드를 실행할 것!
-     * 현재 호출 한 유저가 게시글 작성자인지, 아니면 어드민 권한을 가지고 있는지 확인 후 삭제 기능 수행
+     * 유저 호출에 의한 삭제를 할 경우 이 메소드를 실행할 것! 현재 호출 한 유저가 게시글 작성자인지, 아니면 어드민 권한을 가지고 있는지 확인 후 삭제 기능 수행
      *
      * @param apiId 해당 게시글의 apiId(uuid)
      */

--- a/api/src/main/java/mutsa/api/service/image/ImageModuleService.java
+++ b/api/src/main/java/mutsa/api/service/image/ImageModuleService.java
@@ -14,6 +14,7 @@ import mutsa.api.util.SecurityUtil;
 import mutsa.common.domain.models.Status;
 import mutsa.common.domain.models.image.Image;
 import mutsa.common.domain.models.image.ImageReference;
+import mutsa.common.domain.models.image.ImageStatusFilter;
 import mutsa.common.domain.models.user.User;
 import mutsa.common.exception.BusinessException;
 import mutsa.common.exception.ErrorCode;
@@ -88,7 +89,7 @@ public class ImageModuleService {
 //                .findByUsername(SecurityUtil.getCurrentUsername())
 //                .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
 
-        List<Image> images = imageRepository.getAllByRefApiId(refApiId);
+        List<Image> images = imageRepository.getAllByRefApiIdWithGivenStatus(refApiId, Status.ACTIVE);
 
         images.forEach(image -> image.setStatus(Status.DELETED));
     }
@@ -101,7 +102,7 @@ public class ImageModuleService {
 //                .findByUsername(SecurityUtil.getCurrentUsername())
 //                .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
 
-        List<Image> images = imageRepository.getAllByRefApiId(refApiId);
+        List<Image> images = imageRepository.getAllByRefApiIdWithGivenStatus(refApiId, Status.ACTIVE);
 
         images.forEach(image -> {
             //  일시적으로 유저가 작성한 이미지인지 확인하는 기능 주석
@@ -113,7 +114,15 @@ public class ImageModuleService {
         });
     }
 
-    public List<Image> getAllByRefId(String refApiId) {
-        return imageRepository.getAllByRefApiId(refApiId);
+    public List<Image> getAllByRefId(String refApiId, ImageStatusFilter statusFilter) {
+        List<Image> images;
+        switch (statusFilter) {
+            case ACTIVE, DELETED -> {
+                images = imageRepository.getAllByRefApiIdWithGivenStatus(refApiId, statusFilter.getStatus());
+                break;
+            }
+            default -> images = imageRepository.getAllByRefApiId(refApiId);
+        }
+        return images;
     }
 }

--- a/api/src/main/java/mutsa/api/service/image/ImageModuleService.java
+++ b/api/src/main/java/mutsa/api/service/image/ImageModuleService.java
@@ -29,7 +29,7 @@ public class ImageModuleService {
     private final UserRepository userRepository;
 
     @Transactional
-    public List<Image> saveAll(List<ImagesRequestDto> imagesRequestDtos, String articleApiId) {
+    public List<Image> saveAll(List<ImagesRequestDto> imagesRequestDtos, String refApiId, ImageReference imgRefType) {
         User currentUser = userRepository
                 .findByUsername(SecurityUtil.getCurrentUsername())
                 .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
@@ -43,8 +43,8 @@ public class ImageModuleService {
                             .fileName(imagesRequestDtos.get(i).getFilename())
                             .user(currentUser)
                             .imgIdx(i)
-                            .imageReference(ImageReference.ARTICLE)
-                            .refApiId(articleApiId)
+                            .imageReference(imgRefType)
+                            .refApiId(refApiId)
                             .status(Status.ACTIVE)
                             .build()
             );
@@ -53,35 +53,41 @@ public class ImageModuleService {
         images = imageRepository.saveAll(images);
         return images;
     }
-    @Transactional
-    public List<Image> saveAllReviewImage(List<ImagesRequestDto> imagesRequestDtos, String reviewApiId) {
-        User currentUser = userRepository
-            .findByUsername(SecurityUtil.getCurrentUsername())
-            .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
-
-        List<Image> images = new ArrayList<>();
-
-        for (int i = 0; i < imagesRequestDtos.size(); i++) {
-            images.add(
-                Image.builder()
-                    .path(imagesRequestDtos.get(i).getS3URL())
-                    .fileName(imagesRequestDtos.get(i).getFilename())
-                    .user(currentUser)
-                    .imgIdx(i)
-                    .imageReference(ImageReference.REVIEW)
-                    .refApiId(reviewApiId)
-                    .status(Status.ACTIVE)
-                    .build()
-            );
-        }
-
-        images = imageRepository.saveAll(images);
-        return images;
-    }
+//    @Transactional
+//    public List<Image> saveAllReviewImage(List<ImagesRequestDto> imagesRequestDtos, String reviewApiId) {
+//        User currentUser = userRepository
+//            .findByUsername(SecurityUtil.getCurrentUsername())
+//            .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
+//
+//        List<Image> images = new ArrayList<>();
+//
+//        for (int i = 0; i < imagesRequestDtos.size(); i++) {
+//            images.add(
+//                Image.builder()
+//                    .path(imagesRequestDtos.get(i).getS3URL())
+//                    .fileName(imagesRequestDtos.get(i).getFilename())
+//                    .user(currentUser)
+//                    .imgIdx(i)
+//                    .imageReference(ImageReference.REVIEW)
+//                    .refApiId(reviewApiId)
+//                    .status(Status.ACTIVE)
+//                    .build()
+//            );
+//        }
+//
+//        images = imageRepository.saveAll(images);
+//        return images;
+//    }
 
 
     @Transactional
     public void deleteByRefApiId(String refApiId) {
+        //  REFACTOR 유저 로그인 하는 부분 AOP로 처리해보는 방법 고민하기
+        //  REFACTOR 어드민 권한이 있는 유저의 경우도 예외처리하는 AOP 고민하기
+//        User currentUser = userRepository
+//                .findByUsername(SecurityUtil.getCurrentUsername())
+//                .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
+
         List<Image> images = imageRepository.getAllByRefApiId(refApiId);
 
         images.forEach(image -> image.setStatus(Status.DELETED));
@@ -89,18 +95,25 @@ public class ImageModuleService {
 
     @Transactional
     public void deleteAllByRefId(String refApiId) {
-        User currentUser = userRepository
-                .findByUsername(SecurityUtil.getCurrentUsername())
-                .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
+        //  REFACTOR 유저 로그인 하는 부분 AOP로 처리해보는 방법 고민하기
+        //  REFACTOR 어드민 권한이 있는 유저의 경우도 예외처리하는 AOP 고민하기
+//        User currentUser = userRepository
+//                .findByUsername(SecurityUtil.getCurrentUsername())
+//                .orElseThrow(() -> new BusinessException(ErrorCode.SECURITY_CONTEXT_ERROR));
 
         List<Image> images = imageRepository.getAllByRefApiId(refApiId);
 
         images.forEach(image -> {
-            if (!image.getUser().equals(currentUser)) {
-                throw new BusinessException(ErrorCode.IMAGE_USER_NOT_MATCH);
-            }
+            //  일시적으로 유저가 작성한 이미지인지 확인하는 기능 주석
+//            if (!image.getUser().equals(currentUser)) {
+//                throw new BusinessException(ErrorCode.IMAGE_USER_NOT_MATCH);
+//            }
 
             image.setStatus(Status.DELETED);
         });
+    }
+
+    public List<Image> getAllByRefId(String refApiId) {
+        return imageRepository.getAllByRefApiId(refApiId);
     }
 }

--- a/api/src/main/java/mutsa/api/service/image/ImageService.java
+++ b/api/src/main/java/mutsa/api/service/image/ImageService.java
@@ -1,0 +1,51 @@
+/**
+ * @project backend
+ * @author ARA
+ * @since 2023-10-11 PM 4:50
+ */
+
+package mutsa.api.service.image;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import mutsa.api.dto.image.ImageResponseDto;
+import mutsa.api.dto.image.ImagesRequestDto;
+import mutsa.common.domain.models.image.Image;
+import mutsa.common.domain.models.image.ImageReference;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final ImageModuleService imageModuleService;
+
+    @Transactional
+    public List<ImageResponseDto> saveAll(List<ImagesRequestDto> imagesRequestDtos, String articleApiId, ImageReference imgRefType) {
+        return imageModuleService.saveAll(imagesRequestDtos, articleApiId, imgRefType)
+                .stream()
+                .sorted(Comparator.comparing(Image::getId))
+                .map(image -> ImageResponseDto.to(image))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteByRefApiId(String refApiId) {
+        imageModuleService.deleteByRefApiId(refApiId);
+    }
+
+    @Transactional
+    public void deleteAllByRefId(String refApiId) {
+        imageModuleService.deleteAllByRefId(refApiId);
+    }
+
+    public List<ImageResponseDto> getAllByRefId(String refApiId) {
+        return imageModuleService.getAllByRefId(refApiId)
+                .stream()
+                .sorted(Comparator.comparing(Image::getId))
+                .map(image -> ImageResponseDto.to(image))
+                .collect(Collectors.toList());
+    }
+}

--- a/api/src/main/java/mutsa/api/service/image/ImageService.java
+++ b/api/src/main/java/mutsa/api/service/image/ImageService.java
@@ -14,6 +14,7 @@ import mutsa.api.dto.image.ImageResponseDto;
 import mutsa.api.dto.image.ImagesRequestDto;
 import mutsa.common.domain.models.image.Image;
 import mutsa.common.domain.models.image.ImageReference;
+import mutsa.common.domain.models.image.ImageStatusFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +43,7 @@ public class ImageService {
     }
 
     public List<ImageResponseDto> getAllByRefId(String refApiId) {
-        return imageModuleService.getAllByRefId(refApiId)
+        return imageModuleService.getAllByRefId(refApiId, ImageStatusFilter.ACTIVE)
                 .stream()
                 .sorted(Comparator.comparing(Image::getId))
                 .map(image -> ImageResponseDto.to(image))

--- a/api/src/main/java/mutsa/api/service/review/ReviewService.java
+++ b/api/src/main/java/mutsa/api/service/review/ReviewService.java
@@ -11,6 +11,7 @@ import mutsa.api.service.order.OrderModuleService;
 import mutsa.api.service.user.UserModuleService;
 import mutsa.common.domain.models.article.Article;
 import mutsa.common.domain.models.image.Image;
+import mutsa.common.domain.models.image.ImageReference;
 import mutsa.common.domain.models.order.Order;
 import mutsa.common.domain.models.review.Review;
 import mutsa.common.domain.models.user.User;
@@ -29,8 +30,8 @@ public class ReviewService {
 
     // 리뷰 생성
     public ReviewResponseDto createReview(
-        String articleApiId, String orderApiId, String username, ReviewRequestDto requestDto
-        ) {
+            String articleApiId, String orderApiId, String username, ReviewRequestDto requestDto
+    ) {
         User user = userModuleService.getByUsername(username);
         Article article = articleModuleService.getByApiId(articleApiId);
         Order order = orderModuleService.getByApiId(orderApiId);
@@ -41,8 +42,8 @@ public class ReviewService {
             return ReviewResponseDto.fromEntity(review);
         }
 
-        List<Image> images = imageModuleService.saveAllReviewImage(requestDto.getImages(),
-            review.getApiId());
+        List<Image> images = imageModuleService.saveAll(requestDto.getImages(),
+                review.getApiId(), ImageReference.REVIEW);
         return ReviewResponseDto.fromEntity(reviewModuleService.setImages(review, images));
     }
 
@@ -70,7 +71,8 @@ public class ReviewService {
 
         imageModuleService.deleteByRefApiId(review.getApiId());
         review = deleteImages(review);
-        List<Image> images = imageModuleService.saveAllReviewImage(reviewUpdateDto.getImages(), reviewApiId);
+        List<Image> images = imageModuleService.saveAll(reviewUpdateDto.getImages(), reviewApiId,
+                ImageReference.REVIEW);
         return ReviewResponseDto.fromEntity(reviewModuleService.setImages(review, images));
     }
 

--- a/api/src/test/java/mutsa/api/service/article/ArticleServiceTest.java
+++ b/api/src/test/java/mutsa/api/service/article/ArticleServiceTest.java
@@ -11,6 +11,7 @@ import mutsa.api.config.TestRedisConfiguration;
 import mutsa.api.config.security.CustomPrincipalDetails;
 import mutsa.api.dto.article.ArticleCreateRequestDto;
 import mutsa.api.dto.article.ArticleFilterDto;
+import mutsa.api.dto.article.ArticlePageResponseDto;
 import mutsa.api.dto.article.ArticleResponseDto;
 import mutsa.api.dto.article.ArticleUpdateRequestDto;
 import mutsa.common.domain.models.Status;
@@ -129,7 +130,7 @@ public class ArticleServiceTest {
     @Test
     @DisplayName("Article Service 유저 이름 기반 페이지네이션 테스트")
     public void pageByUsernameTest() {
-        Page<ArticleResponseDto> dtos = articleService.getPageByUsername(
+        Page<ArticlePageResponseDto> dtos = articleService.getPageByUsername(
                 user.getUsername(),
                 Sort.Direction.ASC,
                 ArticleFilterDto.of()
@@ -144,7 +145,7 @@ public class ArticleServiceTest {
     @Test
     @DisplayName("Article Service 페이지네이션 테스트")
     public void pageTest() {
-        Page<ArticleResponseDto> dtos = articleService.getPage(0, 10, Sort.Direction.ASC, ArticleFilterDto.of());
+        Page<ArticlePageResponseDto> dtos = articleService.getPage(0, 10, Sort.Direction.ASC, ArticleFilterDto.of());
 
         assert dtos != null && !dtos.isEmpty();
         for (int i = 0; i < articles.size(); i++) {
@@ -159,7 +160,7 @@ public class ArticleServiceTest {
 
         articles = articleRepository.saveAll(articles);
 
-        Page<ArticleResponseDto> dtos = articleService.getPage(0, 10, Sort.Direction.ASC, ArticleFilterDto.of());
+        Page<ArticlePageResponseDto> dtos = articleService.getPage(0, 10, Sort.Direction.ASC, ArticleFilterDto.of());
 
         assert dtos != null && !dtos.isEmpty();
         Assertions.assertEquals(9, dtos.getNumberOfElements());
@@ -172,7 +173,7 @@ public class ArticleServiceTest {
 
         articles = articleRepository.saveAll(articles);
 
-        Page<ArticleResponseDto> dtos = articleService.getPage(
+        Page<ArticlePageResponseDto> dtos = articleService.getPage(
                 0,
                 10,
                 Sort.Direction.ASC,
@@ -190,7 +191,7 @@ public class ArticleServiceTest {
 
         articles = articleRepository.findAll();
 
-        Page<ArticleResponseDto> dtos = articleService.getPage(
+        Page<ArticlePageResponseDto> dtos = articleService.getPage(
                 0,
                 10,
                 Sort.Direction.ASC,
@@ -202,6 +203,15 @@ public class ArticleServiceTest {
     }
 
     private void checkSameValue(Article articleEntity, ArticleResponseDto articleResponseDto) {
+        Assertions.assertEquals(articleEntity.getApiId(), articleResponseDto.getApiId());
+        Assertions.assertEquals(articleEntity.getTitle(), articleResponseDto.getTitle());
+        Assertions.assertEquals(articleEntity.getDescription(), articleResponseDto.getDescription());
+        Assertions.assertEquals(articleEntity.getUser().getUsername(), articleResponseDto.getUsername());
+        Assertions.assertEquals(articleEntity.getStatus(), articleResponseDto.getStatus());
+        Assertions.assertEquals(articleEntity.getArticleStatus(), articleResponseDto.getArticleStatus());
+    }
+
+    private void checkSameValue(Article articleEntity, ArticlePageResponseDto articleResponseDto) {
         Assertions.assertEquals(articleEntity.getApiId(), articleResponseDto.getApiId());
         Assertions.assertEquals(articleEntity.getTitle(), articleResponseDto.getTitle());
         Assertions.assertEquals(articleEntity.getDescription(), articleResponseDto.getDescription());

--- a/common/src/main/java/mutsa/common/domain/models/article/Article.java
+++ b/common/src/main/java/mutsa/common/domain/models/article/Article.java
@@ -37,6 +37,7 @@ public class Article extends BaseEntity implements Serializable {
     @Column(nullable = false)
     private String description;
 
+    @Column
     private String thumbnail;
 
     @Column(nullable = false)
@@ -53,9 +54,9 @@ public class Article extends BaseEntity implements Serializable {
     @Builder.Default
     private ArticleStatus articleStatus = ArticleStatus.LIVE;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @Builder.Default
-    private List<Image> images = new ArrayList<>();
+//    @OneToMany(fetch = FetchType.LAZY)
+//    @Builder.Default
+//    private List<Image> images = new ArrayList<>();
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "article")
     @Builder.Default
@@ -77,9 +78,9 @@ public class Article extends BaseEntity implements Serializable {
         this.orders.add(order);
     }
 
-    public void addImage(Image image) {this.images.add(image);}
-
-    public void addImages(Collection<Image> imageCollections) {this.images.addAll(imageCollections);}
+//    public void addImage(Image image) {this.images.add(image);}
+//
+//    public void addImages(Collection<Image> imageCollections) {this.images.addAll(imageCollections);}
 
     public boolean validUser(User user) {
         return Objects.equals(this.user.getId(), user.getId());

--- a/common/src/main/java/mutsa/common/domain/models/image/ImageStatusFilter.java
+++ b/common/src/main/java/mutsa/common/domain/models/image/ImageStatusFilter.java
@@ -1,0 +1,21 @@
+/**
+ * @project backend
+ * @author ARA
+ * @since 2023-10-11 PM 7:01
+ */
+
+package mutsa.common.domain.models.image;
+
+import mutsa.common.domain.models.Status;
+
+public enum ImageStatusFilter {
+    ACTIVE, DELETED, ALL;
+
+    public Status getStatus() {
+        if (this == ALL) {
+            return null;
+        }
+
+        return Status.valueOf(this.name());
+    }
+}

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
@@ -55,13 +55,13 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     }
 
     private void doFilter(JPAQuery<Article> query, ArticleFilter articleFilter) {
-        //  게시글 현재 상태에 따른 필터 처리
+        //  게시글 현재 상태에 따른 필터 처리 (숨김, 공개)
         switch (articleFilter.getArticleStatus()) {
             case LIVE, EXPIRED -> query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
             default -> {}
         }
 
-        //  게시글 현재 상태에 따른 필터 처리
+        //  게시글 현재 상태에 따른 필터 처리 (삭제[soft], 존재)
         switch (articleFilter.getStatus()) {
             default -> query.where(article.status.eq(articleFilter.getStatus()));
         }

--- a/common/src/main/java/mutsa/common/repository/image/ImageRepository.java
+++ b/common/src/main/java/mutsa/common/repository/image/ImageRepository.java
@@ -6,15 +6,20 @@
 
 package mutsa.common.repository.image;
 
+import mutsa.common.domain.models.Status;
 import mutsa.common.domain.models.image.Image;
 import mutsa.common.domain.models.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> getAllByRefApiId(String refApiId);
+
+    @Query("SELECT img FROM Image AS img WHERE img.refApiId = :refApiId AND img.status = :status")
+    List<Image> getAllByRefApiIdWithGivenStatus(String refApiId, Status status);
 
     List<Image> getAllByUser(User user);
 


### PR DESCRIPTION
<!--풀리퀘 스트 작성 -->
<!-- 네이밍 방법 [✨Feature] , [📝Docs], [♻️Refactor], [🐛Fix], [🎉Release],   [🏗️Build], [🛠️Project], [✅Test] [🎨Design] 넣고   -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 --> 
- [x] 커밋 메세지 컨벤션 확인
- [x] 기능 수정 시에 테스트 코드 수정확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 풀리퀘스트 네이밍 컨벤션 확인
- [x] 이슈 연동 확인  

## 🔗 이슈 연동
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- 만약 이슈를 닫는 경우 close 부분 작성  -->
<!-- close #NN -->

Linked Issue Number :  #33 
close   #33 


## 📣 새로 생성된 기능을 설명
 - [x] 게시글 목록 조회시 이미지 쿼리로 N+1 발생하는 문제 수정
 - [x] 게시글 목록 dto와 게시글 상세 dto로 분리하여 쿼리 최적화
 - [x] Image 부분 리팩토링 진행
 - [x] Article 부분 리팩토링 진행
 - [x] 이미지 조회시 삭제된 이미지까지 조회하는 문제 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
 - 추가 확인 사항 1