### PR TITLE
[♻️Refactor] 게시글 목록 조회시 성능 개선

### DIFF
--- a/api/src/main/java/mutsa/api/service/article/ArticleModuleService.java
+++ b/api/src/main/java/mutsa/api/service/article/ArticleModuleService.java
@@ -6,16 +6,12 @@
 
 package mutsa.api.service.article;
 
-import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import mutsa.api.dto.article.ArticleCreateRequestDto;
 import mutsa.api.dto.article.ArticleUpdateRequestDto;
 import mutsa.api.util.ArticleUtil;
-import mutsa.api.util.SecurityUtil;
 import mutsa.common.domain.filter.article.ArticleFilter;
 import mutsa.common.domain.models.article.Article;
-import mutsa.common.domain.models.image.Image;
-import mutsa.common.domain.models.user.User;
 import mutsa.common.exception.BusinessException;
 import mutsa.common.repository.article.ArticleRepository;
 import mutsa.common.repository.user.UserRepository;
@@ -28,9 +24,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import static mutsa.common.exception.ErrorCode.ARTICLE_NOT_FOUND;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -131,10 +124,10 @@ public class ArticleModuleService {
     ) {
         Pageable pageable = PageRequest.of(Math.max(0, pageNum), size, direction, orderProperties);
 
-        return articleRepository.getPageByUsername(
-                username,
-                articleFilter,
-                pageable
+        articleFilter.setUsername(username);
+
+        return articleRepository.getPage(
+                articleFilter, pageable
         );
     }
 

--- a/api/src/test/java/mutsa/api/repository/ArticleRepositoryTest.java
+++ b/api/src/test/java/mutsa/api/repository/ArticleRepositoryTest.java
@@ -79,7 +79,8 @@ public class ArticleRepositoryTest {
     @Test
     @DisplayName("유저가 올린 게시글 페이지네이션 테스트")
     public void readAllPageByUsernameTest() {
-        Page<Article> page = articleRepository.getPageByUsername(user1.getUsername(), articleFilter, PAGEABLE);
+        articleFilter.setUsername(user1.getUsername());
+        Page<Article> page = articleRepository.getPage(articleFilter, PAGEABLE);
 
         assert page != null && !page.isEmpty();
         Assertions.assertEquals(articles.size() - 1, page.getNumberOfElements());

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryCustom.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryCustom.java
@@ -11,9 +11,6 @@ import mutsa.common.domain.models.article.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface ArticleRepositoryCustom {
-    Page<Article> getPageByUsername(String username, ArticleFilter articleFilter, Pageable pageable);
     Page<Article> getPage(ArticleFilter articleFilter, Pageable pageable);
 }

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
@@ -57,15 +57,12 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     private void doFilter(JPAQuery<Article> query, ArticleFilter articleFilter) {
         //  게시글 현재 상태에 따른 필터 처리 (숨김, 공개)
         switch (articleFilter.getArticleStatus()) {
-            case LIVE, EXPIRED -> {
-                query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
-            }
-            default -> {}
+            case LIVE, EXPIRED -> query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
         }
 
         //  게시글 현재 상태에 따른 필터 처리 (삭제[soft], 존재)
         switch (articleFilter.getStatus()) {
-            default -> query.where(article.status.eq(articleFilter.getStatus()));
+            case ACTIVE, DELETED -> query.where(article.status.eq(articleFilter.getStatus()));
         }
 
         if (StringUtils.hasText(articleFilter.getTitle())) {

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
@@ -73,7 +73,7 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     }
 
     private Page<Article> getResultPage(JPAQuery<Article> query, Pageable pageable) {
-        List<Article> articleList = getQuerydsl().applyPagination(pageable, query).fetch();
-        return new PageImpl<Article>(articleList, pageable, articleList.size());
+        QueryResults<Article> queryResults = this.getQuerydsl().applyPagination(pageable, query).fetchResults();
+        return new PageImpl<Article>(queryResults.getResults(), pageable, queryResults.getTotal());
     }
 }

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
@@ -6,10 +6,15 @@
 
 package mutsa.common.repository.article;
 
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import mutsa.common.customRepository.Querydsl4RepositorySupport;
 import mutsa.common.domain.filter.article.ArticleFilter;
 import mutsa.common.domain.models.article.Article;
+import mutsa.common.domain.models.article.QArticle;
+import mutsa.common.domain.models.user.QUser;
+import mutsa.common.dto.order.OrderResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -28,20 +33,6 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
         super(Article.class);
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public Page<Article> getPageByUsername(String username, ArticleFilter articleFilter, Pageable pageable) {
-        JPAQuery<Article> query = getQuery();
-
-        query.where(article.user.username.eq(username));
-
-        doFilter(query, articleFilter);
-
-        return getResultPage(query, pageable);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public Page<Article> getPage(ArticleFilter articleFilter, Pageable pageable) {
         JPAQuery<Article> query = getQuery();
 
@@ -55,6 +46,7 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     }
 
     private void doFilter(JPAQuery<Article> query, ArticleFilter articleFilter) {
+
         //  게시글 현재 상태에 따른 필터 처리 (숨김, 공개)
         switch (articleFilter.getArticleStatus()) {
             case LIVE, EXPIRED -> query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
@@ -76,6 +68,8 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
         if (StringUtils.hasText(articleFilter.getUsername())) {
             query.where(article.user.username.eq(articleFilter.getUsername()));
         }
+
+        query.leftJoin(article.user).fetchJoin();
     }
 
     private Page<Article> getResultPage(JPAQuery<Article> query, Pageable pageable) {

--- a/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
+++ b/common/src/main/java/mutsa/common/repository/article/ArticleRepositoryImpl.java
@@ -57,7 +57,9 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     private void doFilter(JPAQuery<Article> query, ArticleFilter articleFilter) {
         //  게시글 현재 상태에 따른 필터 처리 (숨김, 공개)
         switch (articleFilter.getArticleStatus()) {
-            case LIVE, EXPIRED -> query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
+            case LIVE, EXPIRED -> {
+                query.where(article.articleStatus.eq(articleFilter.getArticleStatus()));
+            }
             default -> {}
         }
 
@@ -80,8 +82,7 @@ public class ArticleRepositoryImpl extends Querydsl4RepositorySupport implements
     }
 
     private Page<Article> getResultPage(JPAQuery<Article> query, Pageable pageable) {
-        long totalCount = query.fetch().size();
         List<Article> articleList = getQuerydsl().applyPagination(pageable, query).fetch();
-        return new PageImpl<Article>(articleList, pageable, totalCount);
+        return new PageImpl<Article>(articleList, pageable, articleList.size());
     }
 }


### PR DESCRIPTION
<!--풀리퀘 스트 작성 -->
<!-- 네이밍 방법 [✨Feature] , [📝Docs], [♻️Refactor], [🐛Fix], [🎉Release],   [🏗️Build], [🛠️Project], [✅Test] [🎨Design] 넣고   -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 --> 
- [x] 커밋 메세지 컨벤션 확인
- [x] 기능 수정 시에 테스트 코드 수정확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 풀리퀘스트 네이밍 컨벤션 확인
- [x] 이슈 연동 확인  

## 🔗 이슈 연동
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- 만약 이슈를 닫는 경우 close 부분 작성  -->
<!-- close #NN -->

Linked Issue Number :  #38 
close   #38 


## 📣 새로 생성된 기능을 설명
 - [x] 게시글 목록 조회 시 유저 N+1 문제 발생하는 것 수정
     - [참고링크](https://mon0mon-outline.duckdns.org/s/13b50e7f-b702-4b91-acb1-3e6f7ce32ab4/doc/jpa-n1-wFNUD7yevI#h-유저-n1)
 - [x] 게시글 목록 조회 시 동일한 쿼리 2번 발생하는 문제 수정
    - [참고링크](https://mon0mon-outline.duckdns.org/s/13b50e7f-b702-4b91-acb1-3e6f7ce32ab4/doc/jpa-n1-wFNUD7yevI#h-게시글-n1)

## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
 - 추가 확인 사항 1