### PR TITLE
[♻️Refactor] 영수증 조회 프론트 추가를 위한 리팩토링

### DIFF
--- a/api/src/main/java/mutsa/api/dto/order/OrderDetailResponseDto.java
+++ b/api/src/main/java/mutsa/api/dto/order/OrderDetailResponseDto.java
@@ -19,6 +19,11 @@ public class OrderDetailResponseDto {
     private String date;
     private OrderStatus orderStatus;
     private Long amount;
+    private String receiptApiId;
+
+    public void setReceiptApiId(String receiptApiId) {
+        this.receiptApiId = receiptApiId;
+    }
 
     public static OrderDetailResponseDto fromEntity(Order order) {
         OrderDetailResponseDto orderDetailResponseDto = new OrderDetailResponseDto();

--- a/api/src/main/java/mutsa/api/dto/payment/ReceiptApiIdDto.java
+++ b/api/src/main/java/mutsa/api/dto/payment/ReceiptApiIdDto.java
@@ -1,0 +1,21 @@
+package mutsa.api.dto.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import mutsa.common.domain.models.payment.Receipt;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReceiptApiIdDto {
+    private String receiptApiId;
+
+    public static ReceiptApiIdDto of(Receipt receipt) {
+        ReceiptApiIdDto dto = new ReceiptApiIdDto();
+        dto.receiptApiId = receipt.getApiId();
+        return dto;
+    }
+}

--- a/api/src/main/java/mutsa/api/service/order/OrderService.java
+++ b/api/src/main/java/mutsa/api/service/order/OrderService.java
@@ -7,7 +7,9 @@ import mutsa.api.dto.order.OrderDetailResponseDto;
 import mutsa.api.dto.order.OrderFilterDto;
 import mutsa.api.dto.order.OrderResponseListDto;
 import mutsa.api.dto.order.OrderStatusRequestDto;
+import mutsa.api.dto.payment.ReceiptApiIdDto;
 import mutsa.api.service.article.ArticleModuleService;
+import mutsa.api.service.payment.ReceiptService;
 import mutsa.api.service.user.UserModuleService;
 import mutsa.common.domain.filter.order.OrderFilter;
 import mutsa.common.domain.models.article.Article;
@@ -26,12 +28,16 @@ public class OrderService {
     private final UserModuleService userService;
     private final ArticleModuleService articleModuleService;
     private final OrderModuleService orderModuleService;
+    private final ReceiptService receiptService;
 
     public OrderDetailResponseDto findDetailOrder(String articleApiId, String orderApiId, String currentUsername) {
         User user = userService.getByUsername(currentUsername);
         Article article = articleModuleService.getByApiId(articleApiId);
+        ReceiptApiIdDto receiptApiIdDto = receiptService.getReceiptApiIdByOrderApiId(orderApiId);
+        OrderDetailResponseDto detailOrder = orderModuleService.findDetailOrder(article, user, orderApiId);
+        detailOrder.setReceiptApiId(receiptApiIdDto.getReceiptApiId());
 
-        return orderModuleService.findDetailOrder(article, user, orderApiId);
+        return detailOrder;
     }
 
     public CustomPage<OrderResponseDto> findAllOrder(String articleApiId, String sortOrder, String orderStatus, int page, int limit, String currentUsername) {

--- a/api/src/main/java/mutsa/api/service/payment/ReceiptModuleService.java
+++ b/api/src/main/java/mutsa/api/service/payment/ReceiptModuleService.java
@@ -1,9 +1,13 @@
 package mutsa.api.service.payment;
 
 import lombok.RequiredArgsConstructor;
+import mutsa.common.domain.models.order.Order;
+import mutsa.common.domain.models.payment.Payment;
 import mutsa.common.domain.models.payment.Receipt;
 import mutsa.common.exception.BusinessException;
 import mutsa.common.exception.ErrorCode;
+import mutsa.common.repository.order.OrderRepository;
+import mutsa.common.repository.payment.PaymentRepository;
 import mutsa.common.repository.payment.ReceiptRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,9 +17,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReceiptModuleService {
     private final ReceiptRepository receiptRepository;
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
 
     public Receipt getReceiptByApiId(String receiptApiId) {
         return receiptRepository.findByApiId(receiptApiId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RECEIPT_NOT_FOUND));
+    }
+
+    public Receipt getReceiptByOrderApiId(String orderApiId) {
+        Order order = orderRepository.findByApiId(orderApiId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+        Payment payment = paymentRepository.findByOrder(order)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+        return receiptRepository.findByPayment(payment)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RECEIPT_NOT_FOUND));
     }
 }

--- a/api/src/main/java/mutsa/api/service/payment/ReceiptService.java
+++ b/api/src/main/java/mutsa/api/service/payment/ReceiptService.java
@@ -1,6 +1,7 @@
 package mutsa.api.service.payment;
 
 import lombok.RequiredArgsConstructor;
+import mutsa.api.dto.payment.ReceiptApiIdDto;
 import mutsa.api.dto.payment.ReceiptCardResponseDto;
 import mutsa.api.dto.payment.ReceiptResponseDto;
 import mutsa.common.domain.models.payment.CardReceipt;
@@ -20,5 +21,9 @@ public class ReceiptService {
         ReceiptResponseDto receiptDto = ReceiptResponseDto.of(receipt);
         receiptDto.setCard(receiptCardDto);
         return receiptDto;
+    }
+
+    public ReceiptApiIdDto getReceiptApiIdByOrderApiId(String orderApiId) {
+        return ReceiptApiIdDto.of(receiptModuleService.getReceiptByOrderApiId(orderApiId));
     }
 }

--- a/api/src/test/java/mutsa/api/controller/order/OrderControllerTest.java
+++ b/api/src/test/java/mutsa/api/controller/order/OrderControllerTest.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import mutsa.api.ApiApplication;
 import mutsa.api.config.TestRedisConfiguration;
 import mutsa.api.dto.order.OrderStatusRequestDto;
+import mutsa.api.dto.payment.ReceiptApiIdDto;
+import mutsa.api.service.payment.ReceiptService;
 import mutsa.api.util.SecurityUtil;
 import mutsa.common.domain.models.article.Article;
 import mutsa.common.domain.models.order.Order;
@@ -24,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -39,6 +42,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -69,6 +73,8 @@ class OrderControllerTest {
     private PaymentRepository paymentRepository;
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
+    @MockBean
+    private ReceiptService receiptService;
 
     private static MockedStatic<SecurityUtil> securityUtilMockedStatic;
 
@@ -101,6 +107,10 @@ class OrderControllerTest {
                 .build();
 
         article = articleRepository.save(article);
+
+        ReceiptApiIdDto mockedReceiptApiId = new ReceiptApiIdDto("mockedReceiptApiId");
+        when(receiptService.getReceiptApiIdByOrderApiId(anyString())).thenReturn(mockedReceiptApiId);
+
     }
 
     @AfterEach

--- a/api/src/test/java/mutsa/api/service/order/OrderServiceTest.java
+++ b/api/src/test/java/mutsa/api/service/order/OrderServiceTest.java
@@ -9,6 +9,8 @@ import mutsa.api.dto.CustomPage;
 import mutsa.api.dto.order.OrderDetailResponseDto;
 import mutsa.api.dto.order.OrderFilterDto;
 import mutsa.api.dto.order.OrderStatusRequestDto;
+import mutsa.api.dto.payment.ReceiptApiIdDto;
+import mutsa.api.service.payment.ReceiptService;
 import mutsa.common.domain.models.article.Article;
 import mutsa.common.domain.models.order.Order;
 import mutsa.common.domain.models.order.OrderStatus;
@@ -26,12 +28,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = {ApiApplication.class, TestRedisConfiguration.class})
 @ActiveProfiles("test")
@@ -52,6 +57,8 @@ class OrderServiceTest {
     private PaymentRepository paymentRepository;
     @Autowired
     private RedisTemplate<String, User> userRedisTemplate;
+    @MockBean
+    private ReceiptService receiptService;
     private User seller, consumer;
     private Article article, article2;
 
@@ -78,6 +85,9 @@ class OrderServiceTest {
                 .build();
 
         article2 = articleRepository.save(article2);
+
+        ReceiptApiIdDto mockedReceiptApiId = new ReceiptApiIdDto("mockedReceiptApiId");
+        when(receiptService.getReceiptApiIdByOrderApiId(anyString())).thenReturn(mockedReceiptApiId);
 
     }
 

--- a/common/src/main/java/mutsa/common/repository/payment/PaymentRepository.java
+++ b/common/src/main/java/mutsa/common/repository/payment/PaymentRepository.java
@@ -1,5 +1,6 @@
 package mutsa.common.repository.payment;
 
+import mutsa.common.domain.models.order.Order;
 import mutsa.common.domain.models.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,5 @@ import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderKey(String orderKey);
+    Optional<Payment> findByOrder(Order order);
 }


### PR DESCRIPTION
<!--풀리퀘 스트 작성 -->
<!-- 네이밍 방법 [✨Feature] , [📝Docs], [♻️Refactor], [🐛Fix], [🎉Release],   [🏗️Build], [🛠️Project], [✅Test] [🎨Design] 넣고   -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 --> 
- [ ] 커밋 메세지 컨벤션 확인
- [ ] 기능 수정 시에 테스트 코드 수정확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [ ] 풀리퀘스트 네이밍 컨벤션 확인
- [ ] 이슈 연동 확인  

## 🔗 이슈 연동
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- 만약 이슈를 닫는 경우 close 부분 작성  -->
<!-- close #NN -->

Linked Issue Number :  #41 
close   #41 


## 📣 새로 생성된 기능을 설명
 - [ ] 주문 조회 시, 영수증 정보를 조회하여 receipt api id를 함께 dto에 받아 반환
 - [ ] 영수증 비즈니스 로직에 주문을 통한 조회가 이뤄질 수 있도록 로직 추가
 - [ ] 주문 테스트 코드에 영수증 처리와 관련된 모킹 추가


## 💬 추가 확인 사항
프론 PR GJ-19 (https://github.com/yetJunior/guhaejojibsa-frontend/pull/13) 과 세트입니다. 백엔드의 PR이 먼저 머지되고 프론트의 해당 PR이 머지되어야 정상 작동됩니다.
